### PR TITLE
Fixed: Static data is not reset when the scene is reset

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@
   - Fixed: Occupancy maps are inaccurate.
   - Fixed: Containers and target objects are sometimes initially positioned in mid-air.
   - Fixed: Containers and target objects are sometimes initially positioned where the avatar can't reach them.
+  - Fixed: Static data is not reset when the scene is reset.
   - Reduced the list of possible target objects.
   - `goal_positions` is now a dictionary of room indices, model names, and positions.
 

--- a/sticky_mitten_avatar/sma_controller.py
+++ b/sticky_mitten_avatar/sma_controller.py
@@ -250,6 +250,14 @@ class StickyMittenAvatarController(FloorplanController):
         :param room: The index of the room that the avatar will spawn in the center of. If `scene` or `layout` is None, the avatar will spawn in at (0, 0, 0). If `room == -1` the room will be chosen randomly.
         """
 
+        # Clear all static info.
+        self._target_object_ids: List[int] = list()
+        self._avatar_commands: List[dict] = []
+        self._audio_values: Dict[int, ObjectInfo] = dict()
+        self.static_object_info: Dict[int, StaticObjectInfo] = dict()
+        self.static_avatar_info: Dict[int, BodyPartStatic] = dict()
+        self._cam_commands: Optional[list] = None
+
         # Initialize the scene.
         self.communicate(self._get_scene_init_commands(scene=scene, layout=layout))
 


### PR DESCRIPTION
Closes #79 

Fixed: Static data is not reset when the scene is reset.