### PR TITLE
reset_arm()  will return TaskStatus.no_longer_bending

### DIFF
--- a/Documentation/sma_controller.md
+++ b/Documentation/sma_controller.md
@@ -258,7 +258,8 @@ Possible [return values](task_status.md):
 
 Reset an avatar's arm to its neutral positions.
 Possible [return values](task_status.md):
-- `success` (The avatar's arm reset.)
+- `success` (The arm reset to very close to its initial position.)
+- `no_longer_bending` (The arm stopped bending before it reset, possibly due to an obstacle in the way.)
 
 | Parameter | Description |
 | --- | --- |

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@
   -  Added: optional parameter `precision` to `reach_for_target()` to adjust the threshold at which the action is considered successful.
   -  Added: optional parameter `num_attempts` to `put_in_container()` to adjust the number of attempts it makes before dropping the object.
   -  Adjusted the scale of all containers, the mass of all containers, and the mass of all target objects.
+  -  `reset_arm()` will return `TaskStatus.no_longer_bending` if the arm isn't close to its original position.
   - Fixed: The timestep is different if `demo == True` resulting in different simulation behavior.
   - Fixed: Arm forces don't always reset at the end of an action, which means that the avatar doesn't hold a pose that it should.
   - Fixed: `grasp_object()` will try to grasp an object that is already held. Now, if the object is held, it automatically returns `success`.

--- a/sticky_mitten_avatar/avatars/baby.py
+++ b/sticky_mitten_avatar/avatars/baby.py
@@ -1,7 +1,8 @@
 import numpy as np
+from typing import Dict
 from ikpy.chain import Chain
 from ikpy.link import URDFLink, OriginLink
-from sticky_mitten_avatar.avatars.avatar import Avatar
+from sticky_mitten_avatar.avatars.avatar import Avatar, Arm
 
 
 class Baby(Avatar):
@@ -120,3 +121,7 @@ class Baby(Avatar):
 
     def _get_mass(self) -> float:
         return 80
+
+    def _get_initial_mitten_positions(self) -> Dict[Arm, np.array]:
+        return {Arm.left: np.array([-0.235, 0.08899292, 0.07500012]),
+                Arm.right: np.array([0.235, 0.08899292, 0.07500012])}

--- a/sticky_mitten_avatar/sma_controller.py
+++ b/sticky_mitten_avatar/sma_controller.py
@@ -666,7 +666,8 @@ class StickyMittenAvatarController(FloorplanController):
 
         Possible [return values](task_status.md):
 
-        - `success` (The avatar's arm reset.)
+        - `success` (The arm reset to very close to its initial position.)
+        - `no_longer_bending` (The arm stopped bending before it reset, possibly due to an obstacle in the way.)
 
         :param arm: The arm that will be reset.
         :param do_motion: If True, advance simulation frames until the pick-up motion is done.
@@ -678,7 +679,7 @@ class StickyMittenAvatarController(FloorplanController):
         if do_motion:
             self._do_joint_motion()
         self._end_task()
-        return TaskStatus.success
+        return self._avatar.status
 
     def _do_joint_motion(self) -> None:
         """

--- a/tests/precision_test.py
+++ b/tests/precision_test.py
@@ -9,5 +9,6 @@ if __name__ == "__main__":
     for precision in [0.05, 0.1, 0.15, 0.2, 1]:
         status = c.reach_for_target(target={"x": -0.2, "y": 0.4, "z": 0.385}, arm=Arm.left, precision=precision)
         assert status == TaskStatus.success, status
-        c.reset_arm(arm=Arm.left)
+        status = c.reset_arm(arm=Arm.left)
+        assert status == TaskStatus.success, status
     c.end()


### PR DESCRIPTION
Closes #75 

`reset_arm()` returns `TaskStatus.no_longer_bending` if the arm stops moving before arriving near its initial position relative to the avatar.