### PR TITLE
Remove pour out

### DIFF
--- a/Documentation/arm.md
+++ b/Documentation/arm.md
@@ -1,0 +1,13 @@
+# Arm
+
+`from sticky_mitten_avatar import Arm`
+
+An enum that defines the side that an arm is on.
+
+| Value | Description |
+| --- | --- |
+| `left` | The left arm. |
+| `right` | The right arm. |
+
+***
+

--- a/Documentation/body_part_static.md
+++ b/Documentation/body_part_static.md
@@ -1,6 +1,4 @@
-# `body_part_static.py`
-
-## `BodyPartStatic`
+# BodyPartStatic
 
 `from sticky_mitten_avatar.sticky_mitten_avatar.body_part_static import BodyPartStatic`
 
@@ -25,13 +23,10 @@ Static data for a body part in an avatar, such as a torso, an elbow, etc.
 
 **`def __init__(self, object_id: int, segmentation_color: Tuple[float, float, float], name: str, mass: float)`**
 
-
 | Parameter | Description |
 | --- | --- |
 | object_id | The object ID of the body part. |
 | segmentation_color | The segmentation color of the body part. |
 | name | The name of the body part. |
 | mass | The mass of the body part. |
-
-***
 

--- a/Documentation/frame_data.md
+++ b/Documentation/frame_data.md
@@ -1,6 +1,4 @@
-# `frame_data.py`
-
-## `FrameData`
+# FrameData
 
 `from sticky_mitten_avatar.sticky_mitten_avatar.frame_data import FrameData`
 
@@ -95,13 +93,10 @@ print(c.frame.held_objects[Arm.left])
 
 **`def __init__(self, resp: List[bytes], avatar: Avatar)`**
 
-
 | Parameter | Description |
 | --- | --- |
 | resp | The response from the build. |
 | avatar | The avatar in the scene. |
-
-***
 
 #### save_images
 
@@ -116,8 +111,6 @@ The image pass is a jpg file and the other passes are png files.
 | --- | --- |
 | output_directory | The directory that the images will be saved to. |
 
-***
-
 #### get_pil_images
 
 **`def get_pil_images(self) -> dict`**
@@ -126,13 +119,9 @@ Convert each image pass to PIL images.
 
 _Returns:_  A dictionary of PIL images. Key = the name of the pass (img, id, depth)
 
-***
-
 #### get_depth_values
 
 **`def get_depth_values(self) -> np.array`**
 
 _Returns:_  A decoded depth pass as a numpy array of floats.
-
-***
 

--- a/Documentation/sma_controller.md
+++ b/Documentation/sma_controller.md
@@ -23,6 +23,12 @@ segmentation_colors = c.frame.id_pass
 c.end()
 ```
 
+***
+
+## Parameter types
+
+#### Dict[str, float]
+
 All parameters of type `Dict[str, float]` are Vector3 dictionaries formatted like this:
 
 ```json
@@ -44,6 +50,18 @@ print(target) # {'x': 1.0, 'y': 0.0, 'z': 0.0}
 ```
 
 A parameter of type `Union[Dict[str, float], int]]` can be either a Vector3 or an integer (an object ID).
+
+The types `Dict`, `Union`, and `List` are in the [`typing` module](https://docs.python.org/3/library/typing.html).
+
+#### Arm
+
+All parameters of type `Arm` require you to import the [Arm enum class](arm.md):
+
+```python
+from sticky_mitten_avatar import Arm
+
+print(Arm.left)
+```
 
 ***
 
@@ -383,30 +401,6 @@ Possible [return values](task_status.md):
 
 _Returns:_  A `TaskStatus` indicating whether the avatar moved forward by the distance and if not, why.
 
-#### shake
-
-**`def shake(self, joint_name: str = "elbow_left", axis: str = "pitch", angle: Tuple[float, float] = (20, 30), num_shakes: Tuple[int, int] = (3, 5), force: Tuple[float, float] = (900, 1000)) -> TaskStatus`**
-
-Shake an avatar's arm for multiple iterations.
-Per iteration, the joint will bend forward by an angle and then bend back by an angle.
-The motion ends when all of the avatar's joints have stopped moving.
-
-Possible [return values](task_status.md):
-
-- `success`
-- `bad_joint`
-
-
-| Parameter | Description |
-| --- | --- |
-| joint_name | The name of the joint. |
-| axis | The axis of the joint's rotation. |
-| angle | Each shake will bend the joint by a angle in degrees within this range. |
-| num_shakes | The avatar will shake the joint a number of times within this range. |
-| force | The avatar will add strength to the joint by a value within this range. |
-
-_Returns:_  A `TaskStatus` indicating whether the avatar shook the joint and if not, why.
-
 #### put_in_container
 
 **`def put_in_container(self, object_id: int, container_id: int, arm: Arm) -> TaskStatus`**
@@ -418,6 +412,9 @@ Try to put an object in a container.
 3. The container and its contents will be teleported to be in front of the avatar.
 4. The avatar will move the object over the container and drop it.
 5. The avatar will pick up the container again.
+
+Once an object is placed in a container, _it can not be removed again_.
+The object will be permanently attached to the container.
 
 Possible [return values](task_status.md):
 

--- a/Documentation/sma_controller.md
+++ b/Documentation/sma_controller.md
@@ -433,28 +433,6 @@ _Returns:_  A `TaskStatus` indicating whether the avatar put the object in the c
 
 ***
 
-#### pour_out_container
-
-**`def pour_out_container(self, arm: Arm) -> TaskStatus`**
-
-Pour out the contents of a container held by the arm.
-Assuming that the arm is holding a container, its wrist will twist and the arm will lift.
-If after doing this there are still objects in the container, the avatar will shake the container.
-This action continues until the arm and the objects in the container have stopped moving.
-Possible [return values](task_status.md):
-- `success` (The container held by the arm is now empty.)
-- `not_a_container`
-- `empty_container`
-- `still_in_container`
-
-| Parameter | Description |
-| --- | --- |
-| arm | The arm holding the container. |
-
-_Returns:_  A `TaskStatus` indicating whether the avatar poured all objects out of the container and if not, why.
-
-***
-
 #### rotate_camera_by
 
 **`def rotate_camera_by(self, pitch: float = 0, yaw: float = 0) -> None`**

--- a/Documentation/sma_controller.md
+++ b/Documentation/sma_controller.md
@@ -1,6 +1,4 @@
-# `sma_controller.py`
-
-## `StickyMittenAvatarController(FloorplanController)`
+# StickyMittenAvatarController
 
 `from sticky_mitten_avatar import StickyMittenAvatarController`
 
@@ -130,7 +128,6 @@ for room in c.goal_positions:
 
 **`def __init__(self, port: int = 1071, launch_build: bool = True, demo: bool = False, id_pass: bool = True, screen_width: int = 256, screen_height: int = 256, debug: bool = False)`**
 
-
 | Parameter | Description |
 | --- | --- |
 | port | The port number. |
@@ -141,34 +138,42 @@ for room in c.goal_positions:
 | screen_height | The height of the screen in pixels. |
 | debug | If True, debug mode will be enabled. |
 
-***
-
 #### init_scene
 
 **`def init_scene(self, scene: str = None, layout: int = None, room: int = -1) -> None`**
 
 Initialize a scene, populate it with objects, and add the avatar.
+
 **Always call this function before any other API calls.**
+
 The controller by default will load a simple empty room:
+
 ```python
 from sticky_mitten_avatar import StickyMittenAvatarController
+
 c = StickyMittenAvatarController()
 c.init_scene()
 ```
+
 Set the `scene` and `layout` parameters in `init_scene()` to load an interior scene with furniture and props.
 Set the `room` to spawn the avatar in the center of a room.
+
 ```python
 from sticky_mitten_avatar import StickyMittenAvatarController
+
 c = StickyMittenAvatarController()
 c.init_scene(scene="2b", layout=0, room=1)
 ```
+
 Valid scenes, layouts, and rooms:
+
 | `scene` | `layout` | `room` |
 | --- | --- | --- |
-| 1a, 1b, or 1c | 0, 1, or 2 | 0, 1, 2, 3, 4, 5, 6 |
-| 2a, 2b, or 2c | 0, 1, or 2 | 0, 1, 2, 3, 4, 5, 6, 7, 8 |
-| 4a, 4b, or 4c | 0, 1, or 2 | 0, 1, 2, 3, 4, 5, 6, 7 |
-| 5a, 5b, or 5c | 0, 1, or 2 | 0, 1, 2, 3 |
+| 1a, 1b, 1c | 0, 1, 2 | 0, 1, 2, 3, 4, 5, 6 |
+| 2a, 2b, 2c | 0, 1, 2 | 0, 1, 2, 3, 4, 5, 6, 7, 8 |
+| 4a, 4b, 4c | 0, 1, 2 | 0, 1, 2, 3, 4, 5, 6, 7 |
+| 5a, 5b, 5c | 0, 1, 2 | 0, 1, 2, 3 |
+
 You can safely call `init_scene()` more than once to reset the simulation.
 
 | Parameter | Description |
@@ -177,37 +182,36 @@ You can safely call `init_scene()` more than once to reset the simulation.
 | layout | The furniture layout of the floorplan. If None, the controller will load a simple empty room. |
 | room | The index of the room that the avatar will spawn in the center of. If `scene` or `layout` is None, the avatar will spawn in at (0, 0, 0). If `room == -1` the room will be chosen randomly. |
 
-***
-
 #### communicate
 
 **`def communicate(self, commands: Union[dict, List[dict]]) -> List[bytes]`**
 
-Overrides [`Controller.communicate()`](https://github.com/threedworld-mit/tdw/blob/master/Documentation/python/controller.md).
-Before sending commands, append any automatically-added commands (such as arm-bending or arm-stopping).
-If there is a third-person camera, append commands to look at a target (see `add_overhead_camera()`).
-After receiving a response from the build, update the `frame` data.
+Use this function to send low-level TDW API commands and receive low-level output data. See: [`Controller.communicate()`](https://github.com/threedworld-mit/tdw/blob/master/Documentation/python/controller.md)
+
+You shouldn't ever need to use this function, but you might see it in some of the example controllers because they might require a custom scene setup.
+
 
 | Parameter | Description |
 | --- | --- |
-| commands | Commands to send to the build. |
+| commands | Commands to send to the build. See: [Command API](https://github.com/threedworld-mit/tdw/blob/master/Documentation/api/command_api.md). |
 
-_Returns:_  The response from the build.
-
-***
+_Returns:_  The response from the build as a list of byte arrays. See: [Output Data](https://github.com/threedworld-mit/tdw/blob/master/Documentation/api/output_data.md).
 
 #### reach_for_target
 
 **`def reach_for_target(self, arm: Arm, target: Dict[str, float], do_motion: bool = True, check_if_possible: bool = True, stop_on_mitten_collision: bool = True, precision: float = 0.05, absolute: bool = False) -> TaskStatus`**
 
 Bend an arm joints of an avatar to reach for a target position.
+
 Possible [return values](task_status.md):
+
 - `success` (The avatar's arm's mitten reached the target position.)
 - `too_close_to_reach`
 - `too_far_to_reach`
 - `behind_avatar`
 - `no_longer_bending`
 - `mitten_collision` (If `stop_if_mitten_collision == True`)
+
 
 | Parameter | Description |
 | --- | --- |
@@ -221,8 +225,6 @@ Possible [return values](task_status.md):
 
 _Returns:_  A `TaskStatus` indicating whether the avatar can reach the target and if not, why.
 
-***
-
 #### grasp_object
 
 **`def grasp_object(self, object_id: int, arm: Arm, do_motion: bool = True, check_if_possible: bool = True, stop_on_mitten_collision: bool = True) -> TaskStatus`**
@@ -230,7 +232,9 @@ _Returns:_  A `TaskStatus` indicating whether the avatar can reach the target an
 The avatar's arm will reach for the object. Per frame, the arm's mitten will try to "grasp" the object.
 A grasped object is attached to the avatar's mitten and its ID will be in [`FrameData.held_objects`](frame_data.md). There may be some empty space between a mitten and a grasped object.
 This task ends when the avatar grasps the object (at which point it will stop bending its arm), or if it fails to grasp the object (see below).
+
 Possible [return values](task_status.md):
+
 - `success` (The avatar picked up the object.)
 - `too_close_to_reach`
 - `too_far_to_reach`
@@ -239,6 +243,7 @@ Possible [return values](task_status.md):
 - `failed_to_pick_up`
 - `bad_raycast`
 - `mitten_collision` (If `stop_if_mitten_collision == True`)
+
 
 | Parameter | Description |
 | --- | --- |
@@ -250,14 +255,14 @@ Possible [return values](task_status.md):
 
 _Returns:_  A `TaskStatus` indicating whether the avatar picked up the object and if not, why.
 
-***
-
 #### drop
 
 **`def drop(self, arm: Arm, reset_arm: bool = True, do_motion: bool = True) -> TaskStatus`**
 
 Drop any held objects held by the arm. Reset the arm to its neutral position.
+
 Possible [return values](task_status.md):
+
 - `success` (The avatar's arm dropped all objects held by the arm.)
 
 | Parameter | Description |
@@ -266,14 +271,14 @@ Possible [return values](task_status.md):
 | reset_arm | If True, reset the arm's positions to "neutral". |
 | do_motion | If True, advance simulation frames until the pick-up motion is done. |
 
-***
-
 #### reset_arm
 
 **`def reset_arm(self, arm: Arm, do_motion: bool = True) -> TaskStatus`**
 
 Reset an avatar's arm to its neutral positions.
+
 Possible [return values](task_status.md):
+
 - `success` (The arm reset to very close to its initial position.)
 - `no_longer_bending` (The arm stopped bending before it reset, possibly due to an obstacle in the way.)
 
@@ -282,16 +287,17 @@ Possible [return values](task_status.md):
 | arm | The arm that will be reset. |
 | do_motion | If True, advance simulation frames until the pick-up motion is done. |
 
-***
-
 #### turn_to
 
 **`def turn_to(self, target: Union[Dict[str, float], int], force: float = 1000, stopping_threshold: float = 0.15, num_attempts: int = 200, enable_sensor_on_finish: bool = True) -> TaskStatus`**
 
 Turn the avatar to face a target position or object.
+
 Possible [return values](task_status.md):
+
 - `success` (The avatar turned to face the target.)
 - `too_long` (The avatar made more attempts to turn than `num_attempts`.)
+
 
 | Parameter | Description |
 | --- | --- |
@@ -303,16 +309,17 @@ Possible [return values](task_status.md):
 
 _Returns:_  A `TaskStatus` indicating whether the avatar turned successfully and if not, why.
 
-***
-
 #### turn_by
 
 **`def turn_by(self, angle: float, force: float = 1000, stopping_threshold: float = 0.15, num_attempts: int = 200) -> TaskStatus`**
 
 Turn the avatar by an angle.
+
 Possible [return values](task_status.md):
+
 - `success` (The avatar turned by the angle.)
 - `too_long` (The avatar made more attempts to turn than `num_attempts`.)
+
 
 | Parameter | Description |
 | --- | --- |
@@ -323,19 +330,20 @@ Possible [return values](task_status.md):
 
 _Returns:_  A `TaskStatus` indicating whether the avatar turned successfully and if not, why.
 
-***
-
 #### go_to
 
 **`def go_to(self, target: Union[Dict[str, float], int], turn_force: float = 1000, move_force: float = 80, turn_stopping_threshold: float = 0.15, move_stopping_threshold: float = 0.35, stop_on_collision: bool = True, turn: bool = True, num_attempts: int = 200) -> TaskStatus`**
 
 Move the avatar to a target position or object.
+
 Possible [return values](task_status.md):
+
 - `success` (The avatar arrived at the target.)
 - `too_long` (The avatar made more attempts to move or to turn than `num_attempts`.)
 - `overshot`
 - `collided_with_something_heavy` (if `stop_on_collision == True`)
 - `collided_with_environment` (if `stop_on_collision == True`)
+
 
 | Parameter | Description |
 | --- | --- |
@@ -350,19 +358,20 @@ Possible [return values](task_status.md):
 
 _Returns:_   A `TaskStatus` indicating whether the avatar arrived at the target and if not, why.
 
-***
-
 #### move_forward_by
 
 **`def move_forward_by(self, distance: float, move_force: float = 80, move_stopping_threshold: float = 0.35, stop_on_collision: bool = True, num_attempts: int = 200) -> TaskStatus`**
 
 Move the avatar forward by a distance along the avatar's current forward directional vector.
+
 Possible [return values](task_status.md):
+
 - `success` (The avatar moved forward by the distance.)
 - `too_long` (The avatar made more attempts to move than `num_attempts`.)
 - `overshot`
 - `collided_with_something_heavy` (if `stop_on_collision == True`)
 - `collided_with_environment` (if `stop_on_collision == True`)
+
 
 | Parameter | Description |
 | --- | --- |
@@ -374,8 +383,6 @@ Possible [return values](task_status.md):
 
 _Returns:_  A `TaskStatus` indicating whether the avatar moved forward by the distance and if not, why.
 
-***
-
 #### shake
 
 **`def shake(self, joint_name: str = "elbow_left", axis: str = "pitch", angle: Tuple[float, float] = (20, 30), num_shakes: Tuple[int, int] = (3, 5), force: Tuple[float, float] = (900, 1000)) -> TaskStatus`**
@@ -383,9 +390,12 @@ _Returns:_  A `TaskStatus` indicating whether the avatar moved forward by the di
 Shake an avatar's arm for multiple iterations.
 Per iteration, the joint will bend forward by an angle and then bend back by an angle.
 The motion ends when all of the avatar's joints have stopped moving.
+
 Possible [return values](task_status.md):
+
 - `success`
 - `bad_joint`
+
 
 | Parameter | Description |
 | --- | --- |
@@ -397,20 +407,20 @@ Possible [return values](task_status.md):
 
 _Returns:_  A `TaskStatus` indicating whether the avatar shook the joint and if not, why.
 
-***
-
 #### put_in_container
 
 **`def put_in_container(self, object_id: int, container_id: int, arm: Arm) -> TaskStatus`**
 
 Try to put an object in a container.
+
 1. The avatar will grasp the object and a container via `grasp_object()` if it isn't holding them already.
 2. The avatar will lift the object up.
 3. The container and its contents will be teleported to be in front of the avatar.
 4. The avatar will move the object over the container and drop it.
 5. The avatar will pick up the container again.
-The container will be teleport to
+
 Possible [return values](task_status.md):
+
 - `success` (The avatar put the object in the container.)
 - `too_close_to_reach` (Either the object or the container is too close.)
 - `too_far_to_reach` (Either the object or the container is too far away.)
@@ -423,6 +433,7 @@ Possible [return values](task_status.md):
 - `not_a_container`
 - `full_container`
 
+
 | Parameter | Description |
 | --- | --- |
 | object_id | The ID of the object that the avatar will try to put in the container. |
@@ -431,41 +442,32 @@ Possible [return values](task_status.md):
 
 _Returns:_  A `TaskStatus` indicating whether the avatar put the object in the container and if not, why.
 
-***
-
 #### rotate_camera_by
 
 **`def rotate_camera_by(self, pitch: float = 0, yaw: float = 0) -> None`**
 
-Rotate an avatar's camera around each axis.
-The head of the avatar won't visually rotate, as this could put the avatar off-balance.
-Advances the simulation by 1 frame.
+Rotate an avatar's camera around each axis. The head of the avatar won't visually rotate, as this could put the avatar off-balance.
 
 | Parameter | Description |
 | --- | --- |
 | pitch | Pitch (nod your head "yes") the camera by this angle, in degrees. |
 | yaw | Yaw (shake your head "no") the camera by this angle, in degrees. |
 
-***
-
 #### reset_camera_rotation
 
 **`def reset_camera_rotation(self) -> None`**
 
 Reset the rotation of the avatar's camera.
-Advances the simulation by 1 frame.
-
-***
 
 #### add_overhead_camera
 
 **`def add_overhead_camera(self, position: Dict[str, float], target_object: Union[str, int] = None, cam_id: str = "c", images: str = "all") -> None`**
 
 Add an overhead third-person camera to the scene.
+
 1. `"cam"` (only this camera captures images)
 2. `"all"` (avatars currently in the scene and this camera capture images)
 3. `"avatars"` (only the avatars currently in the scene capture images)
-
 | Parameter | Description |
 | --- | --- |
 | cam_id | The ID of the camera. |
@@ -473,15 +475,11 @@ Add an overhead third-person camera to the scene.
 | position | The position of the camera. |
 | images | Image capture behavior. Choices: |
 
-***
-
 #### end
 
 **`def end(self) -> None`**
 
 End the simulation. Terminate the build process.
-
-***
 
 #### get_occupancy_position
 
@@ -489,12 +487,11 @@ End the simulation. Terminate the build process.
 
 Converts the position (i, j) in the occupancy map to (x, z) coordinates.
 
+
 | Parameter | Description |
 | --- | --- |
 | i | The i coordinate in the occupancy map. |
 | j | The j coordinate in the occupancy map. |
 
 _Returns:_  Tuple: x coordinate; z coordinate.
-
-***
 

--- a/Documentation/static_object_info.md
+++ b/Documentation/static_object_info.md
@@ -1,6 +1,4 @@
-# `static_object_info.py`
-
-## `StaticObjectInfo`
+# StaticObjectInfo
 
 `from sticky_mitten_avatar.sticky_mitten_avatar.static_object_info import StaticObjectInfo`
 
@@ -44,13 +42,10 @@ for container in StaticObjectInfo.CONTAINERS:
 
 **`def __init__(self, object_id: int, rigidbodies: Rigidbodies, segmentation_colors: SegmentationColors, bounds: Bounds, audio: ObjectInfo, target_object: bool = False)`**
 
-
 | Parameter | Description |
 | --- | --- |
 | object_id | The unique ID of the object. |
 | rigidbodies | Rigidbodies output data. |
 | bounds | Bounds output data. |
 | segmentation_colors | Segmentation colors output data. |
-
-***
 

--- a/Documentation/task_status.md
+++ b/Documentation/task_status.md
@@ -36,7 +36,6 @@ Otherwise, the avatar may have tried moving, turning, bending an arm, etc. befor
 | `bad_raycast` | The avatar tried to cast array to the object but the ray was obstructed. |
 | `mitten_collision` | The avatar bent its arm but stopped part-way because the mitten collided with an object. |
 | `not_in_container` | The avatar tried to drop an object in a container but the object isn't in the container. |
-| `bad_joint` | This joint doesn't exist. |
 | `not_a_container` | The avatar didn't try to put one object into another because the other object isn't a container. |
 | `full_container` | The avatar didn't try to put an object in the container because the container has >3 objects. |
 

--- a/Documentation/task_status.md
+++ b/Documentation/task_status.md
@@ -36,14 +36,11 @@ Otherwise, the avatar may have tried moving, turning, bending an arm, etc. befor
 | `collided_with_something_heavy` | The avatar stopped moving because collided with something heavy (mass > 90). |
 | `collided_with_environment` | The avatar stopped moving because it collided with the environment, e.g. a wall. |
 | `bad_raycast` | The avatar tried to cast array to the object but the ray was obstructed. |
-| `failed_to_tap` | The avatar tried to tap the object but the mitten never collided with it. |
 | `mitten_collision` | The avatar bent its arm but stopped part-way because the mitten collided with an object. |
 | `not_in_container` | The avatar tried to drop an object in a container but the object isn't in the container. |
 | `bad_joint` | This joint doesn't exist. |
 | `not_a_container` | The avatar didn't try to put one object into another because the other object isn't a container. |
-| `empty_container` | The avatar didn't try to pour a container because the container was empty. |
-| `still_in_container` | The avatar tried to pour objects out of the container but there are still objects in it. |
-| `full_container` | The container has too many objects. Adding more would result in physics glitches. |
+| `full_container` | The avatar didn't try to put an object in the container because the container has >3 objects. |
 
 ***
 

--- a/Documentation/task_status.md
+++ b/Documentation/task_status.md
@@ -1,6 +1,4 @@
-# `task_status.py`
-
-## `TaskStatus(Enum)`
+# TaskStatus
 
 `from sticky_mitten_avatar.sticky_mitten_avatar.task_status import TaskStatus`
 

--- a/Documentation/transform.md
+++ b/Documentation/transform.md
@@ -1,13 +1,11 @@
-# `transform.py`
-
-## `Transform`
+# Transform
 
 `from sticky_mitten_avatar.sticky_mitten_avatar.transform import Transform`
 
 Transform data for an object, avatar, body part, etc.
 
 ```python
-from sticky_mitten_avatar import StickyMittenAvatarController, Arm
+from sticky_mitten_avatar import StickyMittenAvatarController
 
 c = StickyMittenAvatarController()
 c.init_scene()
@@ -35,12 +33,9 @@ c.end()
 
 **`def __init__(self, position: np.array, rotation: np.array, forward: np.array)`**
 
-
 | Parameter | Description |
 | --- | --- |
 | position | The position of the object as a numpy array. |
 | rotation | The rotation (quaternion) of the object as a numpy array. |
 | forward | The forward directional vector of the object as a numpy array. |
-
-***
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ All example controllers can be found in: `controllers/`
 
 | Controller            | Description                                            |
 | --------------------- | ------------------------------------------------------ |
-| `fill_and_pour.py`    | Fill a container with objects and then pour them out.  |
+| `fill_container.py`   | Fill a container with objects.                         |
 | `social_image.py`     | Generate the social image for the GitHub preview card. |
 | `initialize_scene.py` | Initialize a floorplan populated with objects.         |
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## 0.8.0
+
+### Frontend
+
+- `StickyMittenAvatarController`:
+  - Removed: `pour_out_container()`
+  - Removed: `shake()`
+  - Fixed: The avatar will sometimes veer off-course when trying to move forward.
+  - Fixed: The avatar will sometimes twist when bending its arms.
+  - Fixed: Crash in `put_in_container()` due to the controller sometimes trying to teleport a body part of the avatar.
+- `TaskStatus`:
+  - Removed unused values.
+- Moved the `Arm` enum class to its own file and added documentation.
+- Renamed `fill_and_pour.py` to `fill_container.py` and removed the obsolete pour API call.
+- Fixed a bug in `put_in_container_test.py` in which the avatar would sometimes try to pick up an object already in a container.
+- Documentation:
+  - `StickyMittenAvatarController`:
+    - Organized all functions by category.
+    - Fixed various typos and inaccuracies.
+    - Re-wrote documentation for `communicate()`.
+    - Added a section describing the `Arm` type.
+  - Aesthetic improvements to the headers and section breaks of each document.
+
+### Backend
+
+- Added: `util/api_categories.json` Used for organizing function calls into categories in the documentation.
+- Added code to `doc_gen.py` to format documentation better and organize function calls by category.
+
 ## 0.7.0
 
 ### Frontend

--- a/controllers/fill_container.py
+++ b/controllers/fill_container.py
@@ -6,12 +6,11 @@ from sticky_mitten_avatar.util import CONTAINER_MASS, TARGET_OBJECT_MASS, CONTAI
 
 class FillAndPour(StickyMittenAvatarController):
     """
-    Fill a container with objects and pour objects out when the container is full.
+    Fill a container with objects.
     This controller includes a very basic system for aligning the avatar with an object such it can be picked up.
 
     1. Create a scene with an avatar, a container, and several objects.
     2. Go to each object and put the object in the container.
-    3. If the container is full, pour out the contents and then try again to put the object in the container.
     """
 
     def __init__(self, port: int = 1071):
@@ -120,8 +119,5 @@ if __name__ == "__main__":
                        check_if_possible=False,
                        stop_on_mitten_collision=False)
     c.move_forward_by(0.8)
-    # Pour the contents out.
-    status = c.pour_out_container(arm=Arm.left)
-    assert status == TaskStatus.success, status
     # End the simulation.
     c.end()

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='sticky_mitten_avatar',
-    version="0.7.0",
+    version="0.8.0",
     description='High-level API for the Sticky Mitten Avatar in TDW.',
     long_description='High-level API for the Sticky Mitten Avatar in TDW.',
     url='https://github.com/alters-mit/sticky_mitten_avatar',

--- a/sticky_mitten_avatar/__init__.py
+++ b/sticky_mitten_avatar/__init__.py
@@ -1,2 +1,2 @@
 from .sma_controller import StickyMittenAvatarController
-from .avatars import Arm
+from .arm import Arm

--- a/sticky_mitten_avatar/arm.py
+++ b/sticky_mitten_avatar/arm.py
@@ -1,0 +1,10 @@
+from enum import Enum
+
+
+class Arm(Enum):
+    """
+    An enum that defines the side that an arm is on.
+    """
+
+    left = 0  # The left arm.
+    right = 1  # The right arm.

--- a/sticky_mitten_avatar/avatars/avatar.py
+++ b/sticky_mitten_avatar/avatars/avatar.py
@@ -4,22 +4,13 @@ import numpy as np
 from abc import ABC, abstractmethod
 from ikpy.chain import Chain
 from ikpy.utils import geometry
-from enum import Enum
 from tdw.output_data import OutputData, AvatarStickyMittenSegmentationColors, AvatarStickyMitten, Collision, \
     EnvironmentCollision
 from tdw.tdw_utils import TDWUtils
 from sticky_mitten_avatar.util import get_angle_between, rotate_point_around, FORWARD
 from sticky_mitten_avatar.body_part_static import BodyPartStatic
 from sticky_mitten_avatar.task_status import TaskStatus
-
-
-class Arm(Enum):
-    """
-    The side that an arm is on.
-    """
-
-    left = 0,
-    right = 1
+from sticky_mitten_avatar.arm import Arm
 
 
 class Joint:

--- a/sticky_mitten_avatar/sma_controller.py
+++ b/sticky_mitten_avatar/sma_controller.py
@@ -884,78 +884,6 @@ class StickyMittenAvatarController(FloorplanController):
         return self.go_to(target=target, move_force=move_force, move_stopping_threshold=move_stopping_threshold,
                           stop_on_collision=stop_on_collision, turn=False, num_attempts=num_attempts)
 
-    def shake(self, joint_name: str = "elbow_left", axis: str = "pitch", angle: Tuple[float, float] = (20, 30),
-              num_shakes: Tuple[int, int] = (3, 5), force: Tuple[float, float] = (900, 1000)) -> TaskStatus:
-        """
-        Shake an avatar's arm for multiple iterations.
-        Per iteration, the joint will bend forward by an angle and then bend back by an angle.
-        The motion ends when all of the avatar's joints have stopped moving.
-
-        Possible [return values](task_status.md):
-
-        - `success`
-        - `bad_joint`
-
-        :param joint_name: The name of the joint.
-        :param axis: The axis of the joint's rotation.
-        :param angle: Each shake will bend the joint by a angle in degrees within this range.
-        :param num_shakes: The avatar will shake the joint a number of times within this range.
-        :param force: The avatar will add strength to the joint by a value within this range.
-
-        :return: A `TaskStatus` indicating whether the avatar shook the joint and if not, why.
-        """
-
-        # Check if the joint and axis are valid.
-        joint: Optional[Joint] = None
-        for j in Avatar.JOINTS:
-            if j.joint == joint_name and j.axis == axis:
-                joint = j
-                break
-        if joint is None:
-            return TaskStatus.bad_joint
-
-        self._start_task()
-
-        force = random.uniform(force[0], force[1])
-        damper = 200
-        # Increase the force of the joint.
-        self.communicate(self._avatar.get_start_bend_sticky_mitten_profile(
-            arm=Arm.left if "_left" in joint_name else Arm.right))
-        # Do each iteration.
-        for i in range(random.randint(num_shakes[0], num_shakes[1])):
-            a = random.uniform(angle[0], angle[1])
-            # Start the shake.
-            self.communicate({"$type": "bend_arm_joint_by",
-                              "angle": a,
-                              "joint": joint.joint,
-                              "axis": joint.axis,
-                              "avatar_id": self._avatar.id})
-            for j in range(10):
-                self.communicate([])
-            # Bend the arm back.
-            self.communicate({"$type": "bend_arm_joint_by",
-                              "angle": -(a / 2),
-                              "joint": joint.joint,
-                              "axis": joint.axis,
-                              "avatar_id": self._avatar.id})
-            for j in range(50):
-                self.communicate([])
-            # Apply the motion.
-            self._do_joint_motion()
-        # Reset the force of the joint.
-        self.communicate([{"$type": "adjust_joint_force_by",
-                           "delta": -force,
-                           "joint": joint.joint,
-                           "axis": joint.axis,
-                           "avatar_id": self._avatar.id},
-                          {"$type": "adjust_joint_damper_by",
-                           "delta": damper,
-                           "joint": joint.joint,
-                           "axis": joint.axis,
-                           "avatar_id": self._avatar.id}])
-        self._end_task()
-        return TaskStatus.success
-
     def put_in_container(self, object_id: int, container_id: int, arm: Arm) -> TaskStatus:
         """
         Try to put an object in a container.
@@ -965,6 +893,9 @@ class StickyMittenAvatarController(FloorplanController):
         3. The container and its contents will be teleported to be in front of the avatar.
         4. The avatar will move the object over the container and drop it.
         5. The avatar will pick up the container again.
+
+        Once an object is placed in a container, _it can not be removed again_.
+        The object will be permanently attached to the container.
 
         Possible [return values](task_status.md):
 

--- a/sticky_mitten_avatar/sma_controller.py
+++ b/sticky_mitten_avatar/sma_controller.py
@@ -253,10 +253,10 @@ class StickyMittenAvatarController(FloorplanController):
 
         | `scene` | `layout` | `room` |
         | --- | --- | --- |
-        | 1a, 1b, or 1c | 0, 1, or 2 | 0, 1, 2, 3, 4, 5, 6 |
-        | 2a, 2b, or 2c | 0, 1, or 2 | 0, 1, 2, 3, 4, 5, 6, 7, 8 |
-        | 4a, 4b, or 4c | 0, 1, or 2 | 0, 1, 2, 3, 4, 5, 6, 7 |
-        | 5a, 5b, or 5c | 0, 1, or 2 | 0, 1, 2, 3 |
+        | 1a, 1b, 1c | 0, 1, 2 | 0, 1, 2, 3, 4, 5, 6 |
+        | 2a, 2b, 2c | 0, 1, 2 | 0, 1, 2, 3, 4, 5, 6, 7, 8 |
+        | 4a, 4b, 4c | 0, 1, 2 | 0, 1, 2, 3, 4, 5, 6, 7 |
+        | 5a, 5b, 5c | 0, 1, 2 | 0, 1, 2, 3 |
 
         You can safely call `init_scene()` more than once to reset the simulation.
 
@@ -365,14 +365,13 @@ class StickyMittenAvatarController(FloorplanController):
 
     def communicate(self, commands: Union[dict, List[dict]]) -> List[bytes]:
         """
-        Overrides [`Controller.communicate()`](https://github.com/threedworld-mit/tdw/blob/master/Documentation/python/controller.md).
-        Before sending commands, append any automatically-added commands (such as arm-bending or arm-stopping).
-        If there is a third-person camera, append commands to look at a target (see `add_overhead_camera()`).
-        After receiving a response from the build, update the `frame` data.
+        Use this function to send low-level TDW API commands and receive low-level output data. See: [`Controller.communicate()`](https://github.com/threedworld-mit/tdw/blob/master/Documentation/python/controller.md)
 
-        :param commands: Commands to send to the build.
+        You shouldn't ever need to use this function, but you might see it in some of the example controllers because they might require a custom scene setup.
 
-        :return: The response from the build.
+        :param commands: Commands to send to the build. See: [Command API](https://github.com/threedworld-mit/tdw/blob/master/Documentation/api/command_api.md).
+
+        :return: The response from the build as a list of byte arrays. See: [Output Data](https://github.com/threedworld-mit/tdw/blob/master/Documentation/api/output_data.md).
         """
         if not isinstance(commands, list):
             commands = [commands]
@@ -967,8 +966,6 @@ class StickyMittenAvatarController(FloorplanController):
         4. The avatar will move the object over the container and drop it.
         5. The avatar will pick up the container again.
 
-        The container will be teleport to
-
         Possible [return values](task_status.md):
 
         - `success` (The avatar put the object in the container.)
@@ -1112,9 +1109,7 @@ class StickyMittenAvatarController(FloorplanController):
 
     def rotate_camera_by(self, pitch: float = 0, yaw: float = 0) -> None:
         """
-        Rotate an avatar's camera around each axis.
-        The head of the avatar won't visually rotate, as this could put the avatar off-balance.
-        Advances the simulation by 1 frame.
+        Rotate an avatar's camera around each axis. The head of the avatar won't visually rotate, as this could put the avatar off-balance.
 
         :param pitch: Pitch (nod your head "yes") the camera by this angle, in degrees.
         :param yaw: Yaw (shake your head "no") the camera by this angle, in degrees.
@@ -1134,7 +1129,6 @@ class StickyMittenAvatarController(FloorplanController):
     def reset_camera_rotation(self) -> None:
         """
         Reset the rotation of the avatar's camera.
-        Advances the simulation by 1 frame.
         """
 
         self._start_task()

--- a/sticky_mitten_avatar/sma_controller.py
+++ b/sticky_mitten_avatar/sma_controller.py
@@ -47,6 +47,12 @@ class StickyMittenAvatarController(FloorplanController):
     c.end()
     ```
 
+    ***
+
+    ## Parameter types
+
+    #### Dict[str, float]
+
     All parameters of type `Dict[str, float]` are Vector3 dictionaries formatted like this:
 
     ```json
@@ -68,6 +74,18 @@ class StickyMittenAvatarController(FloorplanController):
     ```
 
     A parameter of type `Union[Dict[str, float], int]]` can be either a Vector3 or an integer (an object ID).
+
+    The types `Dict`, `Union`, and `List` are in the [`typing` module](https://docs.python.org/3/library/typing.html).
+
+    #### Arm
+
+    All parameters of type `Arm` require you to import the [Arm enum class](arm.md):
+
+    ```python
+    from sticky_mitten_avatar import Arm
+
+    print(Arm.left)
+    ```
 
     ***
 

--- a/sticky_mitten_avatar/task_status.py
+++ b/sticky_mitten_avatar/task_status.py
@@ -36,6 +36,5 @@ class TaskStatus(Enum):
     bad_raycast = 13  # The avatar tried to cast array to the object but the ray was obstructed.
     mitten_collision = 14  # The avatar bent its arm but stopped part-way because the mitten collided with an object.
     not_in_container = 15  # The avatar tried to drop an object in a container but the object isn't in the container.
-    bad_joint = 16  # This joint doesn't exist.
-    not_a_container = 17  # The avatar didn't try to put one object into another because the other object isn't a container.
-    full_container = 18  # The avatar didn't try to put an object in the container because the container has >3 objects.
+    not_a_container = 16  # The avatar didn't try to put one object into another because the other object isn't a container.
+    full_container = 17  # The avatar didn't try to put an object in the container because the container has >3 objects.

--- a/sticky_mitten_avatar/task_status.py
+++ b/sticky_mitten_avatar/task_status.py
@@ -34,11 +34,8 @@ class TaskStatus(Enum):
     collided_with_something_heavy = 11  # The avatar stopped moving because collided with something heavy (mass > 90).
     collided_with_environment = 12  # The avatar stopped moving because it collided with the environment, e.g. a wall.
     bad_raycast = 13  # The avatar tried to cast array to the object but the ray was obstructed.
-    failed_to_tap = 14  # The avatar tried to tap the object but the mitten never collided with it.
-    mitten_collision = 15  # The avatar bent its arm but stopped part-way because the mitten collided with an object.
-    not_in_container = 16  # The avatar tried to drop an object in a container but the object isn't in the container.
-    bad_joint = 17  # This joint doesn't exist.
-    not_a_container = 18  # The avatar didn't try to put one object into another because the other object isn't a container.
-    empty_container = 19  # The avatar didn't try to pour a container because the container was empty.
-    still_in_container = 20  # The avatar tried to pour objects out of the container but there are still objects in it.
-    full_container = 21  # The container has too many objects. Adding more would result in physics glitches.
+    mitten_collision = 14  # The avatar bent its arm but stopped part-way because the mitten collided with an object.
+    not_in_container = 15  # The avatar tried to drop an object in a container but the object isn't in the container.
+    bad_joint = 16  # This joint doesn't exist.
+    not_a_container = 17  # The avatar didn't try to put one object into another because the other object isn't a container.
+    full_container = 18  # The avatar didn't try to put an object in the container because the container has >3 objects.

--- a/sticky_mitten_avatar/transform.py
+++ b/sticky_mitten_avatar/transform.py
@@ -6,7 +6,7 @@ class Transform:
     Transform data for an object, avatar, body part, etc.
 
     ```python
-    from sticky_mitten_avatar import StickyMittenAvatarController, Arm
+    from sticky_mitten_avatar import StickyMittenAvatarController
 
     c = StickyMittenAvatarController()
     c.init_scene()

--- a/tests/put_in_container_test.py
+++ b/tests/put_in_container_test.py
@@ -285,6 +285,8 @@ class PutInContainerTest(StickyMittenAvatarController):
             success = self.grasp_and_lift(object_id=container_id, arm=container_arm)
         else:
             success = True
+            # Remove the object from the options of what can be picked up.
+            self.object_ids.remove(target_object_id)
 
         return TaskStatus.success if success else TaskStatus.failed_to_pick_up
 

--- a/util/api_categories.json
+++ b/util/api_categories.json
@@ -4,7 +4,7 @@
     "Constructor": ["__init__"],
     "Scene Setup": ["init_scene", "add_overhead_camera"],
     "Movement": ["turn_to", "turn_by", "go_to", "move_forward_by"],
-    "Arm Articulation": ["reach_for_target", "grasp_object", "drop", "reset_arm", "put_in_container", "shake"],
+    "Arm Articulation": ["reach_for_target", "grasp_object", "drop", "reset_arm", "put_in_container"],
     "Camera": ["rotate_camera_by", "reset_camera_rotation"],
     "Misc.": ["end", "get_occupancy_position", "communicate"]
   }

--- a/util/api_categories.json
+++ b/util/api_categories.json
@@ -1,0 +1,11 @@
+{
+  "StickyMittenAvatarController":
+  {
+    "Constructor": ["__init__"],
+    "Scene Setup": ["init_scene", "add_overhead_camera"],
+    "Movement": ["turn_to", "turn_by", "go_to", "move_forward_by"],
+    "Arm Articulation": ["reach_for_target", "grasp_object", "drop", "reset_arm", "put_in_container", "shake"],
+    "Camera": ["rotate_camera_by", "reset_camera_rotation"],
+    "Misc.": ["end", "get_occupancy_position", "communicate"]
+  }
+}

--- a/util/doc_gen.py
+++ b/util/doc_gen.py
@@ -243,7 +243,8 @@ class PyDocGen:
                  "sticky_mitten_avatar/frame_data.py",
                  "sticky_mitten_avatar/body_part_static.py",
                  "sticky_mitten_avatar/task_status.py",
-                 "sticky_mitten_avatar/transform.py"]
+                 "sticky_mitten_avatar/transform.py",
+                 "sticky_mitten_avatar/arm.py"]
 
         output_directory = Path("Documentation")
         if not output_directory.exists():


### PR DESCRIPTION
See: #92 

# Overview

- Removed `pour_out_container()` and `shake()` because they don't work anymore (because objects are now attached to the container once placed inside).
- Improved the accuracy of the avatar's directional movement and turning.
- Improved documentation.

# List of changes

### Frontend

- `StickyMittenAvatarController`:
  - Removed: `pour_out_container()`
  - Removed: `shake()`
  - Fixed: The avatar will sometimes veer off-course when trying to move forward.
  - Fixed: The avatar will sometimes twist when bending its arms.
  - Fixed: Crash in `put_in_container()` due to the controller sometimes trying to teleport a body part of the avatar.
- `TaskStatus`:
  - Removed unused values.
- Moved the `Arm` enum class to its own file and added documentation.
- Renamed `fill_and_pour.py` to `fill_container.py` and removed the obsolete pour API call.
- Fixed a bug in `put_in_container_test.py` in which the avatar would sometimes try to pick up an object already in a container.
- Documentation:
  - `StickyMittenAvatarController`:
    - Organized all functions by category.
    - Fixed various typos and inaccuracies.
    - Re-wrote documentation for `communicate()`.
    - Added a section describing the `Arm` type.
  - Aesthetic improvements to the headers and section breaks of each document.

### Backend

- Added: `util/api_categories.json` Used for organizing function calls into categories in the documentation.
- Added code to `doc_gen.py` to format documentation better and organize function calls by category.